### PR TITLE
testscript: implement UpdateScripts parameter (#83)

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -121,15 +121,23 @@ func (ts *TestScript) doCmdCmp(args []string, env bool) {
 	name1, name2 := args[0], args[1]
 	text1 := ts.ReadFile(name1)
 
-	data, err := ioutil.ReadFile(ts.MkAbs(name2))
+	absName2 := ts.MkAbs(name2)
+	data, err := ioutil.ReadFile(absName2)
 	ts.Check(err)
 	text2 := string(data)
 	if env {
 		text2 = ts.expand(text2)
 	}
-
 	if text1 == text2 {
 		return
+	}
+	if ts.params.UpdateScripts && !env && (args[0] == "stdout" || args[0] == "stderr") {
+		if scriptFile, ok := ts.scriptFiles[absName2]; ok {
+			ts.scriptUpdates[scriptFile] = text1
+			return
+		}
+		// The file being compared against isn't in the txtar archive, so don't
+		// update the script.
 	}
 
 	ts.Logf("[diff -%s +%s]\n%s\n", name1, name2, textutil.Diff(text1, text2))

--- a/testdata/testscript_update_script.txt
+++ b/testdata/testscript_update_script.txt
@@ -1,0 +1,17 @@
+unquote scripts/testscript.txt
+unquote testscript-new.txt
+testscript-update scripts
+cmp scripts/testscript.txt testscript-new.txt
+
+-- scripts/testscript.txt --
+>echo stdout right
+>cmp stdout expect
+>
+>-- expect --
+>wrong
+-- testscript-new.txt --
+>echo stdout right
+>cmp stdout expect
+>
+>-- expect --
+>right

--- a/testdata/testscript_update_script_not_in_archive.txt
+++ b/testdata/testscript_update_script_not_in_archive.txt
@@ -1,0 +1,12 @@
+unquote scripts/testscript.txt
+cp scripts/testscript.txt unchanged
+! testscript-update scripts
+cmp scripts/testscript.txt unchanged
+
+-- scripts/testscript.txt --
+>echo stdout right
+>cp file expect
+>cmp stdout expect
+>
+>-- file --
+>wrong

--- a/testdata/testscript_update_script_quote.txt
+++ b/testdata/testscript_update_script_quote.txt
@@ -1,0 +1,17 @@
+unquote scripts/testscript.txt
+unquote testscript-new.txt
+testscript-update scripts
+cmp scripts/testscript.txt testscript-new.txt
+
+-- scripts/testscript.txt --
+>echo stdout '-- lookalike --'
+>cmp stdout expect
+>
+>-- expect --
+>wrong
+-- testscript-new.txt --
+>echo stdout '-- lookalike --'
+>cmp stdout expect
+>
+>-- expect --
+>>-- lookalike --

--- a/testdata/testscript_update_script_stderr.txt
+++ b/testdata/testscript_update_script_stderr.txt
@@ -1,0 +1,17 @@
+unquote scripts/testscript.txt
+unquote testscript-new.txt
+testscript-update scripts
+cmp scripts/testscript.txt testscript-new.txt
+
+-- scripts/testscript.txt --
+>echo stderr right
+>cmp stderr expect
+>
+>-- expect --
+>wrong
+-- testscript-new.txt --
+>echo stderr right
+>cmp stderr expect
+>
+>-- expect --
+>right


### PR DESCRIPTION
This makes it possible for a test to automatically update the test scripts
when output changes. Does not cover `cmpenv`.