### PR TITLE
testscript: backport of rogpeppe/go-internal@bf08ea5df4

### DIFF
--- a/testscript.go
+++ b/testscript.go
@@ -152,9 +152,13 @@ func (t tshim) Verbose() bool {
 // RunT is like Run but uses an interface type instead of the concrete *testing.T
 // type to make it possible to use testscript functionality outside of go test.
 func RunT(t T, p Params) {
-	files, err := filepath.Glob(filepath.Join(p.Dir, "*.txt"))
+	glob := filepath.Join(p.Dir, "*.txt")
+	files, err := filepath.Glob(glob)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal(fmt.Sprintf("no scripts found matching glob: %v", glob))
 	}
 	testTempDir, err := ioutil.TempDir(os.Getenv("GOTMPDIR"), "go-test-script")
 	if err != nil {

--- a/testscript_test.go
+++ b/testscript_test.go
@@ -202,6 +202,32 @@ func TestTestwork(t *testing.T) {
 	}
 }
 
+// TestBadDir verifies that invoking testscript with a directory that either
+// does not exist or that contains no *.txt scripts fails the test
+func TestBadDir(t *testing.T) {
+	ft := new(fakeT)
+	func() {
+		defer func() {
+			if err := recover(); err != nil {
+				if err != errAbort {
+					panic(err)
+				}
+			}
+		}()
+		RunT(ft, Params{
+			Dir: "thiswillnevermatch",
+		})
+	}()
+	wantCount := 1
+	if got := len(ft.failMsgs); got != wantCount {
+		t.Fatalf("expected %v fail message; got %v", wantCount, got)
+	}
+	wantMsg := regexp.MustCompile(`no scripts found matching glob: thiswillnevermatch[/\\]\*\.txt`)
+	if got := ft.failMsgs[0]; !wantMsg.MatchString(got) {
+		t.Fatalf("expected msg to match `%v`; got:\n%v", wantMsg, got)
+	}
+}
+
 func setSpecialVal(ts *TestScript, neg bool, args []string) {
 	ts.Setenv("SPECIALVAL", "42")
 }


### PR DESCRIPTION
Backport of [rogpeppe/go-internal@bf08ea5df4](https://github.com/rogpeppe/go-internal/commit/bf08ea5df4ea96c6460011b8a8ef2952494d458d)

Original commit message:

```
commit bf08ea5df4ea96c6460011b8a8ef2952494d458d
Refs: [master], {origin/master}, {origin/HEAD}, <v1.5.1>
Author:     Paul Jolly <paul@myitcv.io>
AuthorDate: Wed Dec 18 16:32:56 2019 +0000
Commit:     GitHub <noreply@github.com>
CommitDate: Wed Dec 18 16:32:56 2019 +0000

    testscript: fail a test when a testscript Dir contains no scripts (#85)

    This can happen when either the Dir does not exist, or it is empty.
```